### PR TITLE
Delete CombineMeshes.meta since CombineMeshes does not exist

### DIFF
--- a/UnityProject/Assets/Kanau/Editor/CombineMeshes.meta
+++ b/UnityProject/Assets/Kanau/Editor/CombineMeshes.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 4bc2dbfe17f785e4a8dd5d3ee55ac140
-folderAsset: yes
-timeCreated: 1468073391
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This fixes an error on import of the code into a new Unity project.